### PR TITLE
Stall detection with encoders

### DIFF
--- a/src/main/java/frc/robot/subsystems/Climber/ClimberWinchSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/Climber/ClimberWinchSubsystem.java
@@ -42,8 +42,8 @@ public class ClimberWinchSubsystem extends SubsystemBase {
 
     powerDistribution = m_PowerDistPanel;
 
-    leftMotorStall = new MotorUtils(Constants.PDP_CLIMBER_L_WINCH, Constants.WINCH_CURR_LIMIT, Constants.CLIMBER_WINCH_CURR_TIMEOUT, m_PowerDistPanel);
-    rightMotorStall = new MotorUtils(Constants.PDP_CLIMBER_R_WINCH, Constants.WINCH_CURR_LIMIT, Constants.CLIMBER_WINCH_CURR_TIMEOUT, m_PowerDistPanel);
+    leftMotorStall = new MotorUtils(Constants.PDP_CLIMBER_L_WINCH, 30, Constants.CLIMBER_WINCH_CURR_TIMEOUT, m_PowerDistPanel, leftWinch, 10);
+    rightMotorStall = new MotorUtils(Constants.PDP_CLIMBER_R_WINCH, 30, Constants.CLIMBER_WINCH_CURR_TIMEOUT, m_PowerDistPanel, rightWinch, 10);
 
     leftWinch.configForwardLimitSwitchSource(LimitSwitchSource.FeedbackConnector, LimitSwitchNormal.NormallyOpen);
     rightWinch.configForwardLimitSwitchSource(LimitSwitchSource.FeedbackConnector, LimitSwitchNormal.NormallyOpen);

--- a/src/main/java/frc/robot/utils/MotorUtils.java
+++ b/src/main/java/frc/robot/utils/MotorUtils.java
@@ -7,6 +7,8 @@
 
 package frc.robot.utils;
 
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.Timer;
@@ -26,6 +28,11 @@ public class MotorUtils {
 
     private boolean everStalled = false;
 
+    private boolean useEncoder = false;
+    private double lastEncoderPosition = 0.0;
+    private double encoderThreshold = 10.0;
+    private WPI_TalonSRX talon;
+
     public MotorUtils(int PDPPort, double currentThreshold, double timeout, PowerDistribution powerDistPanel ){
         this.timeout = timeout;
         this.PDPChannel = PDPPort;
@@ -34,7 +41,36 @@ public class MotorUtils {
         time = Timer.getFPGATimestamp();
     }
 
+    /**
+     * Initialize a MotorUtils object to monitor for stall conditions
+     * @param PDPPort  The PDP port the motor is connected to
+     * @param currentThreshold  How many amps the motor will pull before stalling
+     * @param timeout  How long before declaring a stall condition
+     * @param powerDistPanel The PDP, needed for checking current
+     * @param talon  The motor to monitor, must have encoder enabled
+     * @param encoderThreshold  The encoder threshold, under which the motor will be stalling
+     */
+    public MotorUtils(
+        int PDPPort, 
+        double currentThreshold, 
+        double timeout, 
+        PowerDistribution powerDistPanel, 
+        WPI_TalonSRX talon, 
+        double encoderThreshold) {
+        this(PDPPort, currentThreshold, timeout, powerDistPanel);
+        if (talon == null) {
+            throw new NullPointerException("Cannot Initialize with null Talon");
+        }
+        this.talon = talon;
+        lastEncoderPosition = talon.getSelectedSensorPosition();
+        useEncoder = true;
+        this.encoderThreshold = encoderThreshold;
+    }
+
     public boolean isStalled() {
+        if (useEncoder) {
+            return checkEncoderAndCurrent();
+        }
         final double currentValue = powerDistPanel.getCurrent(PDPChannel);
         final double now = Timer.getFPGATimestamp();
 
@@ -57,5 +93,40 @@ public class MotorUtils {
 
     public void resetStall() {
         everStalled = false;
+    }
+
+    private boolean checkEncoderAndCurrent() {
+        final double currentValue = powerDistPanel.getCurrent(PDPChannel);
+        final double now = Timer.getFPGATimestamp();
+        final double currentEncoder = talon.getSelectedSensorPosition();
+
+        final double encoderTravel = (currentEncoder - lastEncoderPosition);
+
+        boolean isStalled = false;
+
+        if (encoderTravel > encoderThreshold) {
+            if (currentValue < currentThreshold) {
+                // Current is low, motor is turning, no problems
+                time = now;
+            } else {
+                // Is this a concern? Motor is turning but high current
+                // If not this all gets collapsed to one if statement
+                time = now;
+            }
+        } else if (encoderTravel < encoderThreshold) {
+            if (currentValue < currentThreshold) {
+                // Motor is not turning but current is very low, probably not a problem
+                time = now;
+            } else {
+                // Motor is not turning and current is high, bad
+                DriverStation.reportError("Motor stall, PDP Channel=" + PDPChannel, false);
+                if (now - time > timeout) {
+                    Logging.instance().traceMessage(Logging.MessageLevel.INFORMATION, "Motor stall, PDP channel =" + PDPChannel);
+                    isStalled = true;    
+                    everStalled = true;
+                }
+            }
+        }
+        return isStalled;
     }
 }


### PR DESCRIPTION
Adding stall detection with encoders. Initial implementation, I don't know the answer to several important questions:

* What is the threshold of encoder ticking, below which should be considered a stall?
* If a motor is turning, but also has high current, is this a stall condition?

Currently I set three constants:
* Current threshold - I lowered this to 30, with the thought that lower current, but no motor turn, was a better indicator than high current (60 amp) plus turn
* Timeout - Currently this is .3 sec (which is unchanged) - Is this too long to wait before detecting stall? That is ~18 ticks of periodic
* Encoder threshold - I set this to 10, which is admittedly made up. What should this be?